### PR TITLE
Expanded the enum for Errors and added Throws to execute method

### DIFF
--- a/Sources/MySQL/MySQLConnection.swift
+++ b/Sources/MySQL/MySQLConnection.swift
@@ -27,14 +27,15 @@ extension MySQLConnection {
     if CMySQLClient.mysql_real_connect(connection, host, user, password, nil, 0, nil, 0) == nil {
       print("Error: Unable to connect to database")
       close()
-      throw MySQLConnectionError.UnableToCreateConnection
+      throw MySQLConnectionError.UnableToConnectToDatabase
     }
   }
 
-  public func execute(query: String) {
+  public func execute(query: String) throws {
     if (CMySQLClient.mysql_query(connection, query) == 1) {
       print("Error executing query: " + query)
       print(String(cString: CMySQLClient.mysql_error(connection)))
+      throw MySQLConnectionError.UnableToExecuteQuery
       return
     }
 
@@ -42,6 +43,7 @@ extension MySQLConnection {
     if (result == nil) {
       print("Error getting results for: " + query)
       print(String(cString: CMySQLClient.mysql_error(connection)))
+      throw MySQLConnectionError.UnableToReturnResults
       return
     }
 

--- a/Sources/MySQL/MySQLConnectionProtocol.swift
+++ b/Sources/MySQL/MySQLConnectionProtocol.swift
@@ -1,13 +1,16 @@
 import Foundation
 
 public enum MySQLConnectionError: ErrorProtocol {
-  case UnableToCreateConnection
+  case UnableToCreateConnection = "Unable to crate connection to the database"
+  case UnableToConnectToDatabase = "Unable to connect to the specified database"
+  case UnableToExecuteQuery = "Unable to execute the query"
+  case UnableToReturnResults = "Unable to return the results of the query"
 }
 
 public protocol MySQLConnectionProtocol {
   func connect(host: String, user: String, password: String, database: String) throws
   func client_info() -> String?
   func client_version() -> UInt
-  func execute(query: String)
+  func execute(query: String) throws
   func close()
 }


### PR DESCRIPTION
I expanded the entires in the enumeration for Errors and added `Throws` to the `execute()` method in the connection and connection protocol.
